### PR TITLE
resolver: set proxy to `system` if disabled

### DIFF
--- a/src/background/backgroundPage.ts
+++ b/src/background/backgroundPage.ts
@@ -44,6 +44,8 @@ import {consume, torrentSVC} from "../util/webtorrent";
       {urls: ["<all_urls>"]},
       ["blocking"]
     );
+  } else {
+    chrome.proxy.settings.set({value: {mode: 'system'}, scope: 'regular'});
   }
 
   app.on('setting.resolverChanged', (optIn: boolean) => {
@@ -55,6 +57,7 @@ import {consume, torrentSVC} from "../util/webtorrent";
       );
     } else {
       browser.webRequest.onBeforeRequest.removeListener(onBeforeRequest);
+      chrome.proxy.settings.set({value: {mode: 'system'}, scope: 'regular'});
     }
   });
 


### PR DESCRIPTION
Closes #23.

With Bob Wallet taking over Chrome's proxy, it breaks Fingertip and forces users to either disable or uninstall the extension.

This PR sets chrome's proxy settings back to `system` when the "HNS Resolver" feature is disabled in settings.

Since Fingertip works by updating system proxy settings at the OS level, it will work even if chrome says "Bob is controlling this proxy settings".